### PR TITLE
fix(docker): update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: always
     environment:
       POSTGRES_PASSWORD: ${PGPASSWORD}
+      POSTGRES_HOST_AUTH_METHOD: "trust"
     volumes:
       - ./prisma/data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
allow `docker-compose up` to work without setting a `POSTGRES_PASSWORD`

else you'll get :

```
2023-07-18 20:03:19 Error: Database is uninitialized and superuser password is not specified.
2023-07-18 20:03:19        You must specify POSTGRES_PASSWORD to a non-empty value for the
2023-07-18 20:03:19        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run


.....
```